### PR TITLE
Improve contact form UX

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1264,6 +1264,18 @@ line-height: 40px; /* 166.667% */
     padding: 10px 15px; /* added padding for better appearance */
 }
 
+.contact .invalid-feedback {
+    display: none;
+    color: #ed3c0d;
+    font-size: 13px;
+    margin-top: -15px;
+    margin-bottom: 10px;
+}
+
+.contact .form-control.is-invalid {
+    border-color: #ed3c0d;
+}
+
 
 
 /* Input Title Styles */
@@ -1309,6 +1321,10 @@ line-height: 40px; /* 166.667% */
 
 .btn.btn-primary:active {
   transform: scale(0.98);  /* Slight scaling to give a "pressed" effect */
+}
+
+#submitBtn .spinner-border {
+  margin-left: 8px;
 }
 
 /* Responsive behavior */

--- a/index.html
+++ b/index.html
@@ -29,15 +29,69 @@
   <script>
     window.onload = function() {
 
-    document.getElementById("contactForm").addEventListener("submit", async function(event) {
-        event.preventDefault(); // prevent the default form submission
-    
-        const formData = new FormData(event.target); // get form data
+    const form = document.getElementById("contactForm");
+    const toastEl = document.getElementById("successToast");
+    const toast = new bootstrap.Toast(toastEl);
+    const submitBtn = document.getElementById("submitBtn");
+    const spinner = submitBtn.querySelector('.spinner-border');
+    const btnText = submitBtn.querySelector('.button-text');
+
+    const showError = (input, message) => {
+        const feedback = input.parentElement.querySelector('.invalid-feedback');
+        if (feedback) {
+            feedback.textContent = message;
+            feedback.style.display = 'block';
+        }
+        input.classList.add('is-invalid');
+    };
+
+    const clearErrors = () => {
+        form.querySelectorAll('.invalid-feedback').forEach(el => {
+            el.textContent = '';
+            el.style.display = 'none';
+        });
+        form.querySelectorAll('.is-invalid').forEach(el => el.classList.remove('is-invalid'));
+    };
+
+    form.addEventListener("submit", async function(event) {
+        event.preventDefault();
+
+        clearErrors();
+        let hasError = false;
+
+        if (!form.name.value.trim()) {
+            showError(form.name, 'Please enter your name');
+            hasError = true;
+        }
+
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailPattern.test(form.email.value.trim())) {
+            showError(form.email, 'Please enter a valid email');
+            hasError = true;
+        }
+
+        if (!form.subject.value.trim()) {
+            showError(form.subject, 'Subject is required');
+            hasError = true;
+        }
+
+        if (!form.message.value.trim()) {
+            showError(form.message, 'Message is required');
+            hasError = true;
+        }
+
+        if (hasError) return;
+
+        submitBtn.disabled = true;
+        spinner.classList.remove('d-none');
+        btnText.textContent = 'Sending...';
+
+        const formData = new FormData(form);
         const jsonData = {};
         formData.forEach((value, key) => {
             jsonData[key] = value;
         });
-    
+
         try {
             const response = await fetch("https://backendportflio.onrender.com/submit", {
                 method: "POST",
@@ -46,19 +100,22 @@
                 },
                 body: JSON.stringify(jsonData)
             });
-    
+
             const data = await response.json();
-    
+
             if (response.ok) {
-                document.querySelector(".sent-message").textContent = data.message;
-                setTimeout(() => {
-                    location.reload(); // reload the page after a short delay
-                }, 2000); // 2 seconds delay
+                toastEl.querySelector('.toast-body').textContent = data.message;
+                toast.show();
+                form.reset();
             } else {
                 document.querySelector(".error-message").textContent = data.message;
             }
         } catch (error) {
             document.querySelector(".error-message").textContent = "An error occurred. Please try again later.";
+        } finally {
+            submitBtn.disabled = false;
+            spinner.classList.add('d-none');
+            btnText.textContent = 'Send Message';
         }
     });
   };
@@ -273,30 +330,29 @@
   
               <div class="col-lg-6">
                 
-<form id="contactForm" role="form" class="php-email-form">
+<form id="contactForm" role="form" class="php-email-form" novalidate>
 
   <div class="form-group mb-3">
     <label for="inputName">Full name</label>
+    <input type="text" name="name" class="form-control" id="name" placeholder="Enter your full name" required>
+    <div class="invalid-feedback"></div>
+  </div>
+  <div class="form-group mb-3">
+    <label for="inputName">Email</label>
+    <input type="email" class="form-control" name="email" id="email" placeholder="Enter your email" required>
+    <div class="invalid-feedback"></div>
+  </div>
 
-        <input type="text" name="name" class="form-control" id="name" placeholder="Enter your full name" required>
-        </div>
-        <div class="form-group mb-3">
-          <label for="inputName">Email</label>
-
-          <input type="email" class="form-control" name="email" id="email" placeholder="Enter your email" required>
-        </div>
-
-        <div class="form-group mb-3">
-          <label for="inputName">Subject</label>
-
-        <input type="text" class="form-control" name="subject" id="subject" placeholder="Enter your subject" required>
-    </div>
-    <div class="form-group mb-3">
-      <label for="inputName">Message</label>
-
-      
-        <textarea class="form-control" name="message" rows="6" placeholder="Write your message..." required></textarea>
-    </div>
+  <div class="form-group mb-3">
+    <label for="inputName">Subject</label>
+    <input type="text" class="form-control" name="subject" id="subject" placeholder="Enter your subject" required>
+    <div class="invalid-feedback"></div>
+  </div>
+  <div class="form-group mb-3">
+    <label for="inputName">Message</label>
+    <textarea class="form-control" name="message" id="message" rows="6" placeholder="Write your message..." required></textarea>
+    <div class="invalid-feedback"></div>
+  </div>
 
 
                       <div class="my-3">
@@ -304,7 +360,12 @@
                           <div class="error-message"></div>
                           <div class="sent-message">Your message has been sent. Thank you!</div>
                       </div>
-                      <div class="text-center"><button type="submit" class="btn btn-primary">Send Message</button></div>
+                      <div class="text-center">
+                        <button type="submit" class="btn btn-primary" id="submitBtn">
+                          <span class="button-text">Send Message</span>
+                          <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+                        </button>
+                      </div>
                   </form>
               </div>
           </div>
@@ -325,6 +386,18 @@
   </footer><!-- End Footer -->
 
   <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
+
+  <!-- Toast container -->
+  <div class="toast-container position-fixed top-0 end-0 p-3" style="z-index: 11">
+    <div id="successToast" class="toast align-items-center text-bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">
+          Message sent successfully!
+        </div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+  </div>
 
   <!-- Vendor JS Files -->
   <script src="assets/vendor/purecounter/purecounter_vanilla.js"></script>


### PR DESCRIPTION
## Summary
- reset form on successful submission
- show bootstrap toast for success
- validate fields and display inline errors
- polish contact page styles
- show sending spinner inside button
- move toast to the top

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684489e1d25c8326a6f7acb778f1e260